### PR TITLE
Force a resize if the provided value is changed.

### DIFF
--- a/source/index.tsx
+++ b/source/index.tsx
@@ -84,7 +84,7 @@ const ExpandingTextarea: FC<TextareaProps> = ({
 
   useEffect(() => {
     resize(rows, ref.current)
-  }, [ref, rows])
+  }, [ref, rows, props.value])
 
   const handleInput = useCallback(
     (e) => {


### PR DESCRIPTION
This change will only apply to managed inputs.

In [filedrop-web](https://github.com/mat-sz/filedrop-web) I reset the value to '' once the message is submitted. This leaves the old height behind, even after updating the value. This small change recomputes the height if the managed value is changed.

I've tested it on the examples, and this change doesn't impact anything else.