### PR TITLE
Fix onChange prop bug

### DIFF
--- a/source/index.tsx
+++ b/source/index.tsx
@@ -80,7 +80,7 @@ const ExpandingTextarea: FC<TextareaProps> = ({
     isForwardedRefFn || !forwardedRef ? internalRef : forwardedRef
   ) as MutableRefObject<HTMLTextAreaElement>
   const rows = props.rows ? parseInt('' + props.rows, 10) : 0
-  const { onChange, onInput } = props
+  const { onChange, onInput, ...rest } = props
 
   useEffect(() => {
     resize(rows, ref.current)
@@ -112,7 +112,7 @@ const ExpandingTextarea: FC<TextareaProps> = ({
 
   return (
     <textarea
-      {...props}
+      {...rest}
       onInput={handleInput}
       ref={handleRef}
       rows={rows}


### PR DESCRIPTION
If the consumer passes `onChange`, that callback is still passed along to the underlying `textarea`, so the function is executed twice on each user input since React maps `onChange` to the input event as well.