### PR TITLE
Fix: useLayoutEffect over useEffect to let the DOM settle down more

### DIFF
--- a/source/index.tsx
+++ b/source/index.tsx
@@ -5,7 +5,7 @@ import React, {
   RefObject,
   TextareaHTMLAttributes,
   useCallback,
-  useEffect,
+  useLayoutEffect,
   useRef,
 } from 'react'
 import withForwardedRef from 'react-with-forwarded-ref'
@@ -92,7 +92,7 @@ const ExpandingTextarea: FC<TextareaProps> = ({
   const rows = props.rows ? parseInt('' + props.rows, 10) : 0
   const { onChange, onInput, ...rest } = props
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     resize(rows, ref.current)
   }, [ref, rows, props.value])
 


### PR DESCRIPTION
Fixes https://github.com/rpearce/react-expanding-textarea/issues/72